### PR TITLE
Renamed the app

### DIFF
--- a/Pokedex/Base.lproj/Main.storyboard
+++ b/Pokedex/Base.lproj/Main.storyboard
@@ -29,7 +29,7 @@
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="12Z-hO-32r">
                                         <rect key="frame" x="0.0" y="0.0" width="366" height="176"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Pokédex" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="M8X-2G-mdG">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="PokéLearn" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="M8X-2G-mdG">
                                                 <rect key="frame" x="0.0" y="0.0" width="366" height="84"/>
                                                 <fontDescription key="fontDescription" name="FilmotypeJade-Regular" family="Filmotype Jade" pointSize="72"/>
                                                 <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>


### PR DESCRIPTION
@UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo @UnGerardo@UnGerardo @UnGerardo @UnGerardo @UnGerardo 